### PR TITLE
fix for modified RiverWare rdf format

### DIFF
--- a/Applications/PiscesUI/Reclamation.TimeSeries/RiverWare/RiverwareSeries.cs
+++ b/Applications/PiscesUI/Reclamation.TimeSeries/RiverWare/RiverwareSeries.cs
@@ -405,11 +405,16 @@ namespace Reclamation.TimeSeries.RiverWare
                 */
                 string on = m_objectName.Replace("^", "\\^"); // Warren Sharps model had ^ in the object name..
 
-                idxLocation = m_textFile.IndexOfBothRegex("^object_name: " + on + "$", "^slot_name: " + m_slotName + "$", scenarioIndex);
+                idxLocation = m_textFile.IndexOfRegex("^object_name: " + on + "$", scenarioIndex);
                 if (idxLocation >= 0)
                 {
-                    this.Units = ReadUnits(idxLocation);
-                    idxLocation += 5;
+                    var idxSlotName = m_textFile.IndexOfRegex("^slot_name: " + m_slotName + "$", idxLocation);
+                    if (idxSlotName >= 0)
+                    {
+                        var idxEndSlot = m_textFile.IndexOf("END_SLOT_PREAMBLE", idxSlotName);
+                        this.Units = ReadUnits(idxEndSlot);
+                        idxLocation = idxEndSlot + 3; 
+                    }
                 }
             }
             return idxLocation;


### PR DESCRIPTION
CADSWES added slot_type to the rdf format at RiverWare 8.5, which breaks the Pisces code. This change worked on old and new mrm rdf files I tested with.