### PR TITLE
allow backslash or forwardslash in file path

### DIFF
--- a/Applications/RiverWareDMI/Program.cs
+++ b/Applications/RiverWareDMI/Program.cs
@@ -84,7 +84,7 @@ namespace Reclamation.RiverwareDmi
             else if (arguments.Contains("updbfilename"))
             {
                 string pdbFileName = arguments["updbfilename"];
-                Regex regex = new Regex(@"\$(.*?)\\");
+                Regex regex = new Regex(@"\$(.*?)[\\\/]");
                 Match match = regex.Match(pdbFileName);
                 if (match.Success)
                 {


### PR DESCRIPTION
The RiverwareDMI program failed with a pdbFilename path that contained a forward slash. From my testing this works with either slash type.